### PR TITLE
Update Image Links from Squarespace to Cloudinary

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -6,10 +6,13 @@ export default function Footer() {
       <div className="flex flex-col row items-center">
         <div className="flex w-full justify-between items-center">
           <h2>Antelope Enterprise Holdings Limited</h2>
-          <img
-            src="https://images.squarespace-cdn.com/content/65f5178b7e5b446365b2d70a/a8d944de-48ba-45e1-8187-e059b49f996b/%E5%B0%8F%E9%BB%91%E8%89%B2.jpg?content-type=image%2Fpng"
-            alt="logo"
-          />
+          <a href="/">
+            <img
+              src = "https://res.cloudinary.com/aehl/image/upload/v1724428463/%E5%B0%8F%E9%BB%91%E8%89%B2.jpg_dsu0fh.png"
+              alt = "logo"
+              className = "h-full w-full"
+            />
+          </a>
         </div>
         <Divider className="my-2" />
         <div className="flex w-full justify-between space-x-16">

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -60,11 +60,13 @@ export default function NavBar({current, isIRSection}: {current: string, isIRSec
     <div className="flex justify-center">
       <div className="flex row p-0 h-14 justify-between">
         <div className="flex items-center pl-4 py-2">
-          <img
-            src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAOAAAAA/CAMAAADOmzQpAAAA51BMVEUAAAAwMDAwMDAwMDAwMDAwMDAwMDArKysAAAAwMDAuLi4wMDAAAAABAQEBAQEAAAAwMDAEBAQDAwMICAgBAQEBAQECAgIJCQkKCgoBAQEDAwMDAwMwMDALCwsCAgICAgICAgIwMDAICAgICAgICAgBAQECAgIDAwMwMDACAgIDAwMCAgIGBgYJCQkAAAADAwMCAgIDAwMEBAQDAwMHBwcWFhYBAQEDAwMDAwMDAwMEBAQJCQkLCwswMDAwMDACAgIEBAQEBAQHBwcPDw8jIyMDAwMDAwMODg4ICAgbGxswMDAwMDAAAAAwaU8YAAAAS3RSTlMA359gQL/vEP2ABSDx+efikGUfHdrOrTYZ1MOOcBWompVQST4i7L+zr5J8d1Mu37ilgXRhQwz1u5+HajoxMM/IXFpOEgfLcCglCX8VByu7AAAFDElEQVRo3t3aaVfaQBgF4CsIREzYd2QTEBBE3LXVum/t/f+/pwkDCWFCtTh4Dnm+hFLl5DLJzZscYYu+QXiJwJfekpOgt/CnfFls73vwp/xk5Xp9+NOrcQbLxQn8KWqIk/D2B3wqlxGbI/jULsdLeFSCXx22UwBaPIVPpdrFiLkpx5rwqaaWLZibDkcp+NODFh+Ymytq9QJ86WeMnTdzM6R+DF9KZaldphDtkZlX+NKxQW3UfC+S2kov+ZFGsLGN7xaNAqkRp/axMsHwH9NvzGqY73kJB4Gu9SIBt4T1ZgCIbFgvdvCRp5fY8Ke5ve5wIglcvjxBvU1zh6SdCnjGExnG2w24mblM008L4QPJGKnlKrAi5jh2nsKA8TsotzFdnMi3BUyVzDzlgt2nGVpGwJDspKFW0N73re8K2IyRl64cdZq0ClIXZDyvfgGF8DcFTGqMPcAtNzkLkdSpDdSegY5NV/F4Cje+HPAHmZHGs7RGsg5Ta0iqSSgvVQif8NWAu+TzIyQXJEuwFIrU8lBlW0Trik1k9QFbOotncCv1gB7JGMYqGcbSiitm+5eomdUHzHAo7fwl66iS1CCkYrxQWzEBbDk1s9KA+9SupTfT5zwyaKo4h3FSacVsIhIWL1YcMG3wCrIahabzRrugrGLEznbFjq04YI3xJ8juKNgTd6XNusKKCTprebPSgAWNSe9mFZzVPaYRUVgxMM3VTGQn4CURmQQMB9zCnwl4xHYUHq4o7GHqTOcPhRVj2XINpNviv2RBEVD2mYBxluEhdU7BeJ8Z3koKK8Y0rZkGnLiqAx6QB/BwwakT54EGWVFYMZivmcAqAvYZh4dj2oqw6TxRVTHSeq4qYJWXkF1rtJWcUFXW1FWMEBr/M/HvgI0vBIyzD0k6Tsf1bcoZCYrqKkbYmdSMEzAQnLeJaYsG3T7ToobHk/pokTPifXtQvWNbTcWERPs7NbPjBAyqvQ6SaY/D1qV9flvAWJOGgopx380nxM59KeDNvwLKxdijJCO+hRappGKcBzKumkksG1B87K9PBjyiLV4ypgnHP5UmFVSMY8ddM1tfCxj+4BCVLxB7UUTusxwbTS6ECirGEXLXTFBE/f+AcI4CiU73rVKZDlE/g6w9sT3QUPUsxtlhp2YaIvUSATcW/+bQde1+O6TDiEJolnO1gljduIopZmvqBq6aiYjY3Zv/C+h0V8DjNzvsOZeHfZ0zcphXZlVBxQQWTqche2ndGh8EFB8h646v3VkIj32dLvcezzb6KqcYaZppLPdc1BReNOTglCzA2lbP6aZjXovMY2nymSJPM6FlAwYXBoxaA3T+KEZJzePWUVdQMUG4ODWzJe4Ilwi48FZLjC2xNr3kPebWuoobJVnCvlBvB5YMiJ2NBQF36a3k9RDjAF/QXfgY9Cbs7P5mIhT2uF3qetVTYPaQ3w6GfklfjKVIT7tAP+t6RLHHPayjAb08I58h9XfYHsg1/QOaPXoYjeZOxLM4c1hPLZ0LvcxMBHoaa+qYXrT9XbI8M6MOsLbqlGVf0aI9x11ZWddX9FC+zEeBAnllfwOHWGeRC5LSoP1IMXs+5cb3hmvtvcZZ2TOYKmLgPo2Rl1h7+wZt1bPpU+9H5DukloQPHBQpHO5OM7P0cEjy2S9/lpcckswmD6aJdWokM3fwjej9nhXJyJRynWxMLOdgzdtlXuukmtU4pj3X7h7hR0+t/GnzoOCLpfsL/pvEFSLSYzwAAAAASUVORK5CYII="
-            alt="logo"
-            className="h-full w-full"
-          />
+          <a href="/">
+            <img
+              src = "https://res.cloudinary.com/aehl/image/upload/v1724428463/%E5%B0%8F%E9%BB%91%E8%89%B2.jpg_dsu0fh.png"
+              alt = "logo"
+              className = "h-full w-full"
+            />
+          </a>
         </div>
         <div className="md:hidden">
           <MenuOutlined className="h-full pr-4" onClick={openDrawer} />

--- a/src/components/ir/Board.tsx
+++ b/src/components/ir/Board.tsx
@@ -10,63 +10,71 @@ const board: BoardEntry[] = [
     description:
       "Mr. Zhang has served as our Chief Executive Officer since January 2023 and joined our Board in February 2023. From 2011 to 2020, he acted as the Chairman of Huitong Tianxia Investment Ltd., an investment company. Since 2020, Mr. Zhang has acted as the chariman of Jinke Yulv Technology Co., Ltd., which is an International Technology firm in China. Mr. Zhang completed the course and obtained a Diploma in Capital and M&A Entrepreneurship from Fudan University in 2021, and a Diploma in Finance and Capital Investment from Southwest University in Finance and Economics in 2014.",
     image:
-      "  https://images.squarespace-cdn.com/content/v1/65f5178b7e5b446365b2d70a/078ea913-4f11-49ae-a1fa-980bc7ae2081/weilai-zhang.png",
+      "https://res.cloudinary.com/aehl/image/upload/v1724428444/weilai-zhang_drtijr.png",
   },
   {
     name: "Chungen Song",
     description:
       "Mr. Chungen Song joined our Board in November 2019 as an independent member of the Board as well as a member of Audit, Compensation and Nominating Committees, to fill the vacancy following Liu Jun’s resignation. From 2009 to present, Song Chungen has been a practicing lawyer at Guangdong Weihao Law firm. He obtained his law license in May 2003, and in November 2009, he obtained Securities Qualification in China. Song Chungen holds a Bachelor’s degree in Law from Sun Yat Sen University (2007).",
     image:
-      "https://images.squarespace-cdn.com/content/v1/65f5178b7e5b446365b2d70a/817a6b3e-0916-449a-b87c-1e43449181ee/chungen-song.png",
+      // "https://images.squarespace-cdn.com/content/v1/65f5178b7e5b446365b2d70a/817a6b3e-0916-449a-b87c-1e43449181ee/chungen-song.png",
+      "https://res.cloudinary.com/aehl/image/upload/v1724428447/chungen-song_pzyogy.png",
   },
   {
     name: "Tingting Zhang",
     description:
       "Ms. Tingting Zhang joined our Board in October 2022. Ms. Zhang joined China Mobile’s digital content subsidiary Migo Co Ltd in 2021 at its Xiamen headquarters as the manager of its post-production department. Her current responsibilities include video production of programs including the 2022 Winter Olympics, the Golden Rooster Award and other large-scale China award productions. Previous to that, from 2018 to 2021, Ms. Zhang worked as a multimedia designer at 4399 Networks Ltd., where she was responsible for media productions. Ms. Zhang graduated with a Bachelor’s degree in Design from Asia University Taiwan.",
     image:
-      "https://images.squarespace-cdn.com/content/v1/65f5178b7e5b446365b2d70a/c924d2c3-715e-4a38-b6af-12ad2f92c4c9/tingting-zhang.jpg",
+      // "https://images.squarespace-cdn.com/content/v1/65f5178b7e5b446365b2d70a/c924d2c3-715e-4a38-b6af-12ad2f92c4c9/tingting-zhang.jpg",
+      "https://res.cloudinary.com/aehl/image/upload/v1724428446/tingting-zhang.jpg_mbwhp1.png",
   },
   {
     name: "Dian Zhang",
     description:
       "Mr. Dian Zhang joined our Board in November 2022. Mr. Dian Zhang is currently Chief Financial Officer of Baiya International Group Inc., an SaaS (software as a service) platform company in China. Previously, Mr. Zhang worked at Eaton Square from 2014 to 2020, an M&A advisory firm, where he was responsible for investments in new ventures and their financing in the Chinese market. Previous to that, Mr. Zhang worked at the Chengdu branch of ShineWing Certified Public Accountants from 2009 to 2013 where his responsibilities included the auditing of annual reports of publicly listed companies and due diligence for IPO projects. Mr. Zhang holds a Bachelor’s degree in Management Accounting from Aston University, a Master’s degree in Banking and Finance from Monash University, and a Master’s degree in Financial Management from the Australian National University.",
     image:
-      "https://images.squarespace-cdn.com/content/v1/65f5178b7e5b446365b2d70a/81b0bf75-d8e6-4070-b454-756bfbada527/dian-zhang.png",
+      // "https://images.squarespace-cdn.com/content/v1/65f5178b7e5b446365b2d70a/81b0bf75-d8e6-4070-b454-756bfbada527/dian-zhang.png",
+      "https://res.cloudinary.com/aehl/image/upload/v1724428442/dian-zhang_omdytk.png",
   },
   {
     name: "Ishak Han",
     description:
       "Mr. Ishak Han joined our Board in November 2022. Mr. Han is the General Manager of Shenzhen Baisifu Industrial Co., Ltd., which engages in property management and leasing, management services for catering businesses, and enterprise management consulting. Having founded the firm in 2017, Mr. Han developed Shenzhen Baisifu Industrial Co., Ltd.’s marketing strategy, management policies, financial budgeting, and corporate planning activities. From 2011 to 2016, Mr. Han was the General Manager of Shenzhen Baisi Technology Co., Ltd. which engages in the development of self-service website application systems, the training and development of online ventures, online marketing training, and e-commerce product consignments. As the founder of Shenzhen Baisi Technology Co., Ltd., Mr. Han oversaw its financial budgeting and corporate planning functions, and was responsible for its overall marketing strategy. Mr. Han graduated with a higher degree diploma in marketing from Guangdong Open University in 2021.",
     image:
-      "https://images.squarespace-cdn.com/content/v1/65f5178b7e5b446365b2d70a/4aa710ce-5693-4089-b8a5-e328ad12f0b8/ishak-han.png",
+      // "https://images.squarespace-cdn.com/content/v1/65f5178b7e5b446365b2d70a/4aa710ce-5693-4089-b8a5-e328ad12f0b8/ishak-han.png",
+      "https://res.cloudinary.com/aehl/image/upload/v1724428442/ishak-han_eolqsr.png",
   },
   {
     name: "Huashu Yuan",
     description:
       "Ms. Huashu Yuan joined our Board in March 2023. Ms. Yuan has been the marketing specialist of Vesta living corp. since March 2022. Ms. Yuan served as an outside consultant providing marketing advice to the Company from June 2021 to February 2023. Ms. Yuan served as the marketing manager for American Tianfu-Wenhui Publishing Company from March 2021 to February 2022. Ms. Yuan worked at Strands Haircare Inc. as a social media intern from October 2020 to February 2021. Ms. Yuan obtained her Master’s degree in Emerging Media Studies from Boston University in 2020 and obtained her Bachelor’s degree in Communication Science and Rhetoric Studies from University of Wisconsin-Madison in 2019.",
     image:
-      "https://images.squarespace-cdn.com/content/v1/65f5178b7e5b446365b2d70a/f94c3a73-ac76-405f-b80d-ea8449d96ac5/huashu-yuan.png",
+      // "https://images.squarespace-cdn.com/content/v1/65f5178b7e5b446365b2d70a/f94c3a73-ac76-405f-b80d-ea8449d96ac5/huashu-yuan.png",
+      "https://res.cloudinary.com/aehl/image/upload/v1724428441/huashu-yuan_tdkfdp.png",
   },
   {
     name: "Xiaoying Song",
     description:
       "Ms. Xiaoying Song has extensive experience in business administration and operations as well as investment management, and has been a co-founder of several companies. Ms. Song is currently the CEO of Sichuan Huanyu Interchange Group Co., Ltd, which she co-founded in January of 2020; the firm operates as a bidding agency for contracts, and engages in engineering supervision, construction labor subcontracting and other related businesses. From October 2016 to December 2020, Ms. Song co-founded and was the CEO of Chengdu Houshi Technology Co., Ltd, which engages in technology development, technical services and information technology consulting services. From July 2013 to September 2016, Ms. Song co-founded and was the CEO of Chengdu Huaxin Wealth Management Co., Ltd, an investment management, investment consulting, and business services firm. Ms. Song obtained an Associates Degree in Air Crew from Nanchang Institute of Technology in 2013.",
     image:
-      "https://images.squarespace-cdn.com/content/v1/65f5178b7e5b446365b2d70a/7d4783a7-72b5-40fc-96ce-67e8bac617b5/xiaoying-song.jpg",
+      // "https://images.squarespace-cdn.com/content/v1/65f5178b7e5b446365b2d70a/7d4783a7-72b5-40fc-96ce-67e8bac617b5/xiaoying-song.jpg",
+      "https://res.cloudinary.com/aehl/image/upload/v1724428443/xiaoying-song_g5iuh2.jpg",
   },
   {
     name: "Junjie Dong",
     description:
       'Mr. Junjie Dong is currently the Chief Technology Officer of Antelope Holdings (Chengdu) Co., Ltd., a wholly owned subsidiary of the Company that is engaged in computer consulting and software development. Mr. Dong is responsible for its strategic direction and overseeing its technological advancements, and he has held this position since July 2023. From February 2018 to July 2023, Mr. Dong was the Chief Executive Officer ("CEO") of Shenzhen Hongtaiju Technology Development Co., Ltd., an information technology company, where he was mainly responsible for the company\'s strategic planning and operational management. From August 2015 to December 2018, Mr. Dong was CEO of Shenzhen Weidai Yingxing Financial Services Co., Ltd, a company that provides financial services. From May 2013 to July 2015, he was the CEO of Shenzhen Hongtaiju Investment Consulting Co., Ltd., a company that provides financial services. Mr. Dong attended Hainan Vocational College of Science and Technology from March 2015 to December 2018, and received the junior college degree.',
     image:
-      "https://images.squarespace-cdn.com/content/v1/65f5178b7e5b446365b2d70a/1b6bb272-086b-4fd5-a35e-75132587b392/WechatIMG21.jpg",
+      // "https://images.squarespace-cdn.com/content/v1/65f5178b7e5b446365b2d70a/1b6bb272-086b-4fd5-a35e-75132587b392/WechatIMG21.jpg",
+      "https://res.cloudinary.com/aehl/image/upload/v1724429516/WechatIMG21_rb7qxg.jpg",
   },
   {
     name: "Houyou Zhang",
     description:
       "Mr. Houyou Zhang has been a director of YiXiang International LLC since March 2023, where he secures projects for investment and conducted due diligence. From May 2017 to October 2022, Mr. Zhang was the chairman of Shanghai KKM Asset Management Co., Ltd., a firm that he founded and where he was engaged in investment and asset management. Mr. Zhang is experienced in quantitative trading in China with 20 years of experience in the finance industry, and he has published widely on finance and investments. Mr. Zhang received a Bachelor’s degree in Engineering from Sichuan University in 2002.",
     image:
-      "https://images.squarespace-cdn.com/content/v1/65f5178b7e5b446365b2d70a/eeb9e429-cc8b-4d1c-9986-d47d460838fa/Image_20240618105142.jpg",
+      // "https://images.squarespace-cdn.com/content/v1/65f5178b7e5b446365b2d70a/eeb9e429-cc8b-4d1c-9986-d47d460838fa/Image_20240618105142.jpg",
+      "https://res.cloudinary.com/aehl/image/upload/v1724429464/Image_20240618105142_spfcnp.jpg",
   },
 ];
 
@@ -81,8 +89,8 @@ export default function BoardRow() {
           // Apply background style to the entire row if it's an alternate row
           const rowStyle = isOddRow
             ? {
-                backgroundImage:
-                  "url('https://www.aehlus.com/png/img12.f4ed389f.png')",
+                // backgroundImage:
+                //   "url('https://www.aehlus.com/png/img12.f4ed389f.png')",
                 backgroundSize: "cover",
               }
             : {};

--- a/src/components/ir/DocumentsTable.tsx
+++ b/src/components/ir/DocumentsTable.tsx
@@ -9,23 +9,23 @@ type DocumentType = {
 const documents: DocumentType[] = [
   {
     name: "The Code of Ethics",
-    url: "https://aehltd.squarespace.com/s/Antelope-Enterprise-Code-of-Ethics.pdf",
+    url: "https://res.cloudinary.com/aehl/image/upload/v1724337827/Antelope_Enterprise_-_Code_of_Ethics_yrnrnc.pdf",
   },
   {
     name: "The Charter of the Audit Committee",
-    url: "https://aehltd.squarespace.com/s/Antelope-Enterprise-Audit-Committee-Charter.pdf",
+    url: "https://res.cloudinary.com/aehl/image/upload/v1724337827/Antelope_Enterprise_-_Audit_Committee_Charter_adf130.pdf",
   },
   {
     name: "The Charter of the Nomination Committee",
-    url: "https://aehltd.squarespace.com/s/Antelope-Enterprise-Governance-and-Nominating-Committee-Charter.pdf",
+    url: "https://res.cloudinary.com/aehl/image/upload/v1724337827/Antelope_Enterprise_-_Governance_and_Nominating_Committee_Charter_kdcaur.pdf",
   },
   {
     name: "The Charter of the Compensation Committee",
-    url: "https://aehltd.squarespace.com/s/Antelope-Enterprise-Compensation-Committee-Charter-Amended-Restated-zzkb.pdf",
+    url: "https://res.cloudinary.com/aehl/image/upload/v1724337828/Antelope_Enterprise_-_Compensation_Committee_Charter_-_Amended_Restated_ts9arz.pdf",
   },
   {
     name: "Whistleblower Policy of China Ceramics",
-    url: "https://aehltd.squarespace.com/s/Antelope-Enterprise-Whistleblower-Policy.pdf",
+    url: "https://res.cloudinary.com/aehl/image/upload/v1724337827/Antelope_Enterprise_-_Whistleblower_Policy_esfsyr.pdf"
   },
 ];
 

--- a/src/pages/aehl-kylin/model.tsx
+++ b/src/pages/aehl-kylin/model.tsx
@@ -31,7 +31,7 @@ export default function KylinModel() {
         className="bg-local flex w-full h-[40vh] bg-center justify-center"
         style={{
           backgroundImage:
-            "url('https://images.squarespace-cdn.com/content/65f5178b7e5b446365b2d70a/24942941-dc52-4b21-afd5-1143691ddbdd/%E5%BE%AE%E4%BF%A1%E5%9B%BE%E7%89%87_20230601145557.jpg?content-type=image%2Fjpeg')",
+            "url('https://res.cloudinary.com/aehl/image/upload/v1724428457/image5-1_vawwhv.jpg')",
           backgroundSize: "cover ",
         }}
       ></div>
@@ -77,17 +77,11 @@ export default function KylinModel() {
           </div>
         </div>
       </div>
-      <div
-        className="flex bg-local w-full justify-center"
-        style={{
-          backgroundImage:
-            "url('https://www.aehlus.com/png/img12.f4ed389f.png')",
-          backgroundSize: "cover",
-        }}
-      >
+      <div className="flex bg-local w-full justify-center">
         <div className="flex row flex-col">
           <h1>Our Services</h1>
-          <div className="flex flex-col md:flex-row items-center justify-center">
+          <div className="flex flex-col md:flex-row items-center justify-center"
+                style={{height:"36vh"}}>
             <div className="flex items-center justify-center my-4 md:mr-8 w-full md:w-1/2">
               <div
                 style={{

--- a/src/pages/aehl-kylin/overview.tsx
+++ b/src/pages/aehl-kylin/overview.tsx
@@ -9,14 +9,14 @@ export default function KylinOverview() {
           className="absolute inset-0 bg-cover bg-center"
           style={{
             backgroundImage:
-              "url('https://images.squarespace-cdn.com/content/65f5178b7e5b446365b2d70a/585c5fdd-4198-4d3c-b0b4-d7a9d6aac4e9/%E5%BE%AE%E4%BF%A1%E5%9B%BE%E7%89%87_20230601145549.jpg')",
+              "url('https://res.cloudinary.com/aehl/image/upload/v1724428455/image4-1_va07bo.jpg')",
             backgroundSize: "cover",
           }}
         ></div>
         <div className="absolute inset-0 bg-slate-500 opacity-25"></div>
         <div className="relative z-10 flex flex-col w-full h-full items-center justify-center p-16 space-y-16">
           <img
-            src="https://images.squarespace-cdn.com/content/v1/65f5178b7e5b446365b2d70a/e55ba965-5b03-4ee7-80f7-da4419ea35ee/%E5%A4%A7%E7%99%BD%E8%89%B2.jpg"
+            src="https://res.cloudinary.com/aehl/image/upload/v1724428464/%E5%A4%A7%E7%99%BD%E8%89%B2.jpg_voicgv.png"
             alt="Logo"
             className="w-full md:w-3/4 drop-shadow-2xl"
           />
@@ -53,7 +53,7 @@ export default function KylinOverview() {
         className="bg-local flex w-full justify-center"
         style={{
           backgroundImage:
-            "url('https://www.aehlus.com/png/img12.f4ed389f.png')",
+            "url('https://res.cloudinary.com/aehl/image/upload/v1724429466/img12.f4ed389f_te7lgl.png')",
           backgroundSize: "cover",
         }}
       >
@@ -104,7 +104,7 @@ export default function KylinOverview() {
       <div className="flex row flex-col md:flex-row">
         <div className="flex my-4 md:mr-8 md:mb-0 md:w-1/2">
           <img
-            src="https://images.squarespace-cdn.com/content/65f5178b7e5b446365b2d70a/0e1e7924-1981-49cc-89fa-73f5628f7890/6049046d97a5fe05f83d64ebfe1b7a4.jpg"
+            src="https://res.cloudinary.com/aehl/image/upload/v1724428454/image2-2_fjgknc.jpg"
             alt="business"
             className="w-full h-full object-cover"
           />
@@ -138,43 +138,43 @@ export default function KylinOverview() {
             <div className="flex w-full flex-col md:flex-row 4xl:w-1/2 justify-evenly items-center">
               <div className="flex w-full justify-evenly items-center">
                 <img
-                  src="https://images.squarespace-cdn.com/content/65f5178b7e5b446365b2d70a/fab2712b-12d3-4c03-9675-989518ecc72a/%E5%B0%8F%E7%BA%A2%E4%B9%A6.png"
+                  src="https://res.cloudinary.com/aehl/image/upload/v1724428447/%E5%B0%8F%E7%BA%A2%E4%B9%A6_d5u9yo.png"
                   alt="小红书"
                 />
                 <img
-                  src="https://images.squarespace-cdn.com/content/65f5178b7e5b446365b2d70a/6539c476-f692-4534-b1e4-054df8be1a7f/%E5%BF%AB%E6%89%8B.png"
+                  src = "https://res.cloudinary.com/aehl/image/upload/v1724428451/%E5%BF%AB%E6%89%8B_fvsuyq.png"
                   alt="快手"
                 />
               </div>
               <div className="flex w-full justify-evenly items-center">
                 <img
-                  src="https://images.squarespace-cdn.com/content/65f5178b7e5b446365b2d70a/a23b9ad8-d18a-46a9-8ae8-90e8e92dc2f8/%E4%BA%AC%E4%B8%9C.png"
-                  alt="京东"
+                  src = "https://res.cloudinary.com/aehl/image/upload/v1724428451/%E4%BA%AC%E4%B8%9C_b5u9vi.png"
+                  alt = "京东"
                 />
                 <img
-                  src="https://images.squarespace-cdn.com/content/65f5178b7e5b446365b2d70a/a2a95e4e-12f2-46bc-aab1-7d6e7fdd2028/%E4%BB%8A%E6%97%A5%E5%A4%B4%E6%9D%A1.png"
-                  alt="头条"
+                  src = "https://res.cloudinary.com/aehl/image/upload/v1724428453/%E4%BB%8A%E6%97%A5%E5%A4%B4%E6%9D%A1_vfu7wc.png"
+                  alt = "今日头条"
                 />
               </div>
             </div>
             <div className="flex w-full flex-col md:flex-row 4xl:w-1/2 justify-evenly items-center">
               <div className="flex w-full justify-evenly items-center">
                 <img
-                  src="https://images.squarespace-cdn.com/content/65f5178b7e5b446365b2d70a/798d4e5a-3400-4c41-b636-ab94eeb749e3/TikTok.png"
+                  src = "https://res.cloudinary.com/aehl/image/upload/v1724428449/TikTok_aepoag.png"
                   alt="TikTok"
                 />
                 <img
-                  src="https://images.squarespace-cdn.com/content/65f5178b7e5b446365b2d70a/fbe24af6-4372-4279-8518-fa2f9f9543a3/%E6%8A%96%E9%9F%B3.png"
+                  src = "https://res.cloudinary.com/aehl/image/upload/v1724428448/%E6%8A%96%E9%9F%B3_sctelm.png"
                   alt="抖音"
                 />
               </div>
               <div className="flex w-full justify-evenly items-center">
                 <img
-                  src="https://images.squarespace-cdn.com/content/65f5178b7e5b446365b2d70a/114f7b2e-77fa-4fe3-9717-bd0f83c56570/%E5%93%94%E5%93%A9%E5%93%94%E5%93%A9.png"
+                  src = "https://res.cloudinary.com/aehl/image/upload/v1724428449/%E5%93%94%E5%93%A9%E5%93%94%E5%93%A9_idd9e3.png"
                   alt="哔哩哔哩"
                 />
                 <img
-                  src="https://images.squarespace-cdn.com/content/65f5178b7e5b446365b2d70a/d1438c86-ca12-4dc0-a6b0-dd54bf116fa7/%E8%A5%BF%E7%93%9C%E8%A7%86%E9%A2%91.png"
+                  src = "https://res.cloudinary.com/aehl/image/upload/v1724428452/%E8%A5%BF%E7%93%9C%E8%A7%86%E9%A2%91_jzim14.png"
                   alt="西瓜视频"
                 />
               </div>

--- a/src/pages/aehl-us/overview.tsx
+++ b/src/pages/aehl-us/overview.tsx
@@ -6,7 +6,7 @@ export default function USOverview() {
           className="absolute inset-0 bg-cover bg-center"
           style={{
             backgroundImage:
-              "url('https://www.aehlus.com/png/img1.c6bbf8d2.png')",
+              "url('https://res.cloudinary.com/aehl/image/upload/v1724430440/img1.c6bbf8d2_jabqxm.png')",
             backgroundSize: "cover",
             backgroundPosition: "center",
           }}
@@ -14,7 +14,7 @@ export default function USOverview() {
         <div className="absolute inset-0 bg-slate-500 opacity-25"></div>
         <div className="relative z-10 flex flex-col w-full h-full items-center p-16 justify-center">
           <img
-            src="https://images.squarespace-cdn.com/content/v1/65f5178b7e5b446365b2d70a/e55ba965-5b03-4ee7-80f7-da4419ea35ee/%E5%A4%A7%E7%99%BD%E8%89%B2.jpg"
+            src = "https://res.cloudinary.com/aehl/image/upload/v1724428464/%E5%A4%A7%E7%99%BD%E8%89%B2.jpg_voicgv.png"
             alt="Logo"
             className="w-full md:w-3/4 drop-shadow-2xl"
           />
@@ -76,7 +76,7 @@ export default function USOverview() {
         className="bg-local flex w-full justify-center"
         style={{
           backgroundImage:
-            "url('https://www.aehlus.com/png/img12.f4ed389f.png')",
+            "url('https://res.cloudinary.com/aehl/image/upload/v1724429466/img12.f4ed389f_te7lgl.png')",
           backgroundSize: "cover",
         }}
       >
@@ -87,7 +87,7 @@ export default function USOverview() {
               <div className="relative">
                 <img
                   className="object-cover w-full h-full"
-                  src="https://www.aehlus.com/png/Strengths-1.a36a67d4.png"
+                  src="https://res.cloudinary.com/aehl/image/upload/v1724430443/Strengths_1_hwjy8h.png"
                   alt="bg"
                 />
                 <div className="absolute inset-0 bg-custom-gradient"></div>
@@ -104,7 +104,7 @@ export default function USOverview() {
               <div className="relative">
                 <img
                   className="object-cover w-full h-full"
-                  src="https://www.aehlus.com/png/Strengths-2.b90e5967.png"
+                  src="https://res.cloudinary.com/aehl/image/upload/v1724430438/Strengths-2.b90e5967_tczbv2.png"
                   alt="bg"
                 />
                 <div className="absolute inset-0 bg-custom-gradient"></div>
@@ -123,7 +123,7 @@ export default function USOverview() {
               <div className="relative">
                 <img
                   className="object-cover w-full h-full"
-                  src="https://www.aehlus.com/png/Strengths-3.9e5a1c57.png"
+                  src="https://res.cloudinary.com/aehl/image/upload/v1724430445/Strengths-3.9e5a1c57_o0u5yc.png"
                   alt="bg"
                 />
                 <div className="absolute inset-0 bg-custom-gradient"></div>
@@ -140,7 +140,7 @@ export default function USOverview() {
               <div className="relative">
                 <img
                   className="object-cover w-full h-full"
-                  src="https://www.aehlus.com/png/Strengths-4.d4502d8c.png"
+                  src="https://res.cloudinary.com/aehl/image/upload/v1724430442/Strengths-4.d4502d8c_vi00ya.png"
                   alt="bg"
                 />
                 <div className="absolute inset-0 bg-custom-gradient"></div>
@@ -161,7 +161,7 @@ export default function USOverview() {
       <div className="flex row flex-col space-y-8 md:flex-row md:justify-between md:space-x-16 md:space-y-0">
         <img
           className="md:w-1/2 object-cover h-full"
-          src="https://www.aehlus.com/png/img6.c41aed10.png"
+          src="https://res.cloudinary.com/aehl/image/upload/v1724430439/img6.c41aed10_sjc3zh.png"
           alt="bg"
         />
         <div className="flex flex-col md:w-1/2 justify-center">

--- a/src/pages/aehl-us/products.tsx
+++ b/src/pages/aehl-us/products.tsx
@@ -10,7 +10,7 @@ export default function USProducts() {
         className="bg-local flex w-full h-[40vh] justify-center"
         style={{
           backgroundImage:
-            "url('https://www.aehlus.com/png/img4.50ec3eb4.png')",
+            "url('https://res.cloudinary.com/aehl/image/upload/v1724430441/img4.50ec3eb4_vgyxwa.png')",
           backgroundSize: "cover",
         }}
       ></div>
@@ -18,7 +18,7 @@ export default function USProducts() {
         <div className="md:w-1/2 ml-0">
           <img
             className="object-cover h-full w-full"
-            src="https://www.aehlus.com/png/img7.6170bfe8.png"
+            src="https://res.cloudinary.com/aehl/image/upload/v1724430442/img7.6170bfe8_vq3cnh.png"
             alt="bg"
           />
         </div>

--- a/src/pages/contact-us.tsx
+++ b/src/pages/contact-us.tsx
@@ -7,7 +7,7 @@ export default function ContactUs() {
         className="bg-local flex w-full h-[65vh] justify-center"
         style={{
           backgroundImage:
-            "url('https://www.aehlus.com/png/img3.0cd01d99.png')",
+            "url('https://res.cloudinary.com/aehl/image/upload/v1724430444/img3.0cd01d99_ukqlxc.png')",
           backgroundSize: "cover",
           backgroundPosition: "center",
         }}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -9,27 +9,22 @@ export default function Home() {
 
   return (
     <div id="container" className="container">
-      <div className="relative flex w-full justify-center overflow-hidden text-center">
-        <div
-          className="absolute inset-0 bg-cover bg-center filter blur-sm"
-          style={{
-            backgroundImage: `url(https://images.squarespace-cdn.com/content/65f5178b7e5b446365b2d70a/340d967e-cf1f-4c4e-ab6d-b44c8737a53f/3D.jpg)`,
-            backgroundSize: "cover",
-            backgroundPosition: "center",
-          }}
-        ></div>
-        <div className="absolute inset-0 bg-slate-700 opacity-50"></div>
-        <div className="relative z-10 flex flex-col w-full h-full items-center p-16 justify-center">
-          <img
-            src="https://images.squarespace-cdn.com/content/v1/65f5178b7e5b446365b2d70a/e55ba965-5b03-4ee7-80f7-da4419ea35ee/%E5%A4%A7%E7%99%BD%E8%89%B2.jpg"
-            alt="logo"
-            className="w-full md:w-3/4 drop-shadow-3xl"
-          />
-          <h2 className="mt-16 text-white font-semibold drop-shadow-lg">
+      <div  className="relative flex justify-center items-center text-center w-full h-full bg-cover"
+            style={{backgroundImage:'url(https://res.cloudinary.com/aehl/image/upload/v1724428460/3D_dohdwm.jpg)',
+                    backgroundSize: "cover",
+                    backgroundPosition: "center",
+                    aspectRatio: '16/9',
+                    }}>
+          <h2 className="absolute inline-block w-3/4 text-white font-semibold drop-shadow-lg"
+              style={{
+                top: '80%', // Position the text at 80% from the top
+                transform: 'translateY(-50%)', // Adjust for vertical alignment
+                // fontSize: 'clamp(1rem, 3vw, 2.5rem)',
+                fontSize: '2.7vw',
+              }}>
             A Beacon of Innovation in an Evolving Energy and Technology
             Landscape
           </h2>
-        </div>
       </div>
 
       <div className="flex w-full bg-slate-400 justify-center text-white">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -64,7 +64,7 @@ export default function Home() {
         className="bg-local flex flex-col w-full items-center p-10"
         style={{
           backgroundImage:
-            "url('https://www.aehlus.com/png/img12.f4ed389f.png')",
+            "url('https://res.cloudinary.com/aehl/image/upload/v1724429466/img12.f4ed389f_te7lgl.png')",
           backgroundSize: "cover",
         }}
       >
@@ -93,7 +93,7 @@ export default function Home() {
               </div>
               <div className="col-span-1">
                 <img
-                  src="https://plus.unsplash.com/premium_photo-1661715583676-165c827b1cff?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+                  src="https://res.cloudinary.com/aehl/image/upload/v1724684787/Untitled_design_xpg7sk.jpg"
                   alt="kylin img"
                   className="w-full h-full object-cover rounded-xl shadow-lg"
                 />
@@ -103,7 +103,7 @@ export default function Home() {
 
           <div className="relative md:hidden h-[80vh]">
             <img
-              src="https://plus.unsplash.com/premium_photo-1661715583676-165c827b1cff?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+              src="https://res.cloudinary.com/aehl/image/upload/v1724684787/Untitled_design_xpg7sk.jpg"
               alt="kylin img"
               className="m-16 -mr-24 w-full h-2/3 object-cover rounded-s-xl shadow-lg"
             />
@@ -131,13 +131,12 @@ export default function Home() {
             <div className="grid grid-cols-2 w-full py-8 3xl:py-16 4xl:py-20">
               <div className="col-span-1">
                 <img
-                  src="https://images.squarespace-cdn.com/content/65f5178b7e5b446365b2d70a/449012af-b66b-4de0-b1a8-3d3e85b9196d/24990dd2bc453748013327e58d39340.jpg?content-type=image%2Fjpeg"
+                  src="https://res.cloudinary.com/aehl/image/upload/v1724428459/image1_c9ca55.jpg"
                   alt="kylin img"
                   className="w-full h-full object-cover rounded-xl shadow-lg"
                 />
               </div>
               <div className="col-span-1 flex justify-center">
-                {/* <div className="halfrow items-end mt-32"> */}
                   <div className="halfrow flex flex-col p-8 bg-white shadow-lg rounded-xl mt-32">
                     <h1 className="mb-4">The Livestreaming Ecommerce Frontier</h1>
                     <p>
@@ -155,7 +154,6 @@ export default function Home() {
                       </Link>
                     </div>
                   </div>
-                {/* </div> */}
               </div>
 
             </div>
@@ -163,7 +161,7 @@ export default function Home() {
 
           <div className="relative md:hidden h-[80vh]">
             <img
-              src="https://images.squarespace-cdn.com/content/65f5178b7e5b446365b2d70a/449012af-b66b-4de0-b1a8-3d3e85b9196d/24990dd2bc453748013327e58d39340.jpg?content-type=image%2Fjpeg"
+              src="https://res.cloudinary.com/aehl/image/upload/v1724428459/image1_c9ca55.jpg"
               alt="kylin img"
               className="m-16 -ml-24 w-full h-2/3 object-cover rounded-e-xl shadow-lg"
             />
@@ -212,9 +210,9 @@ export default function Home() {
           </div>
           <div className="flex flex-col items-end justify-end">
             <img
-              src="https://images.squarespace-cdn.com/content/v1/65f5178b7e5b446365b2d70a/078ea913-4f11-49ae-a1fa-980bc7ae2081/weilai-zhang.png"
+              src="https://res.cloudinary.com/aehl/image/upload/v1724428444/weilai-zhang_drtijr.png"
               alt="ceo"
-              className="w-56 mb-8 object-cover rounded-md drop-shadow-md"
+              className="w-56 mb-2 object-cover rounded-md drop-shadow-md"
             />
             <h2>Weilai &quot;Will&quot; Zhang</h2>
             <p>AEHL Chairman and CEO</p>

--- a/src/pages/ir/events-presentations.tsx
+++ b/src/pages/ir/events-presentations.tsx
@@ -14,11 +14,11 @@ export default function IREventsPresentationsPage() {
       </div>
       <div
         className="bg-local flex w-full justify-center"
-        style={{
-          backgroundImage:
-            "url('https://www.aehlus.com/png/img12.f4ed389f.png')",
-          backgroundSize: "cover",
-        }}
+        // style={{
+        //   backgroundImage:
+        //     "url('https://res.cloudinary.com/aehl/image/upload/v1724429466/img12.f4ed389f_te7lgl.png')",
+        //   backgroundSize: "cover",
+        // }}
       >
         <div id="presentation" className="row">
           <h1 className="mb-4">Past Events</h1>

--- a/src/pages/ir/press-releases.tsx
+++ b/src/pages/ir/press-releases.tsx
@@ -41,11 +41,11 @@ export default function IRNews() {
 
       <div
         className="bg-local flex flex-col w-full items-center"
-        style={{
-          backgroundImage:
-            "url('https://www.aehlus.com/png/img12.f4ed389f.png')",
-          backgroundSize: "cover",
-        }}
+        // style={{
+        //   backgroundImage:
+        //     "url('https://www.aehlus.com/png/img12.f4ed389f.png')",
+        //   backgroundSize: "cover",
+        // }}
       >
         <div className="row">
           <QModFooter />

--- a/src/pages/ir/sec-filings.tsx
+++ b/src/pages/ir/sec-filings.tsx
@@ -39,11 +39,11 @@ export default function IRSECFilings() {
         </div>
         <div
           className="bg-local flex flex-col w-full items-center"
-          style={{
-            backgroundImage:
-              "url('https://www.aehlus.com/png/img12.f4ed389f.png')",
-            backgroundSize: "cover",
-          }}
+          // style={{
+          //   backgroundImage:
+          //     "url('https://www.aehlus.com/png/img12.f4ed389f.png')",
+          //   backgroundSize: "cover",
+          // }}
         >
           <div className="row">
             <QModFooter />

--- a/src/pages/ir/stock-information.tsx
+++ b/src/pages/ir/stock-information.tsx
@@ -75,11 +75,11 @@ export default function IRStockInfo() {
       </div> */}
       <div
         className="bg-local flex flex-col w-full items-center"
-        style={{
-          backgroundImage:
-            "url('https://www.aehlus.com/png/img12.f4ed389f.png')",
-          backgroundSize: "cover",
-        }}
+        // style={{
+        //   backgroundImage:
+        //     "url('https://www.aehlus.com/png/img12.f4ed389f.png')",
+        //   backgroundSize: "cover",
+        // }}
       >
         <div className="row">
           <QModFooter />


### PR DESCRIPTION
1. Updated the majority of image URLs in the project to now point to Cloudinary instead of Squarespace.
2. The video on the /aehl-kylin/model and /aehl-kylin/overview pages remains hosted on Squarespace.